### PR TITLE
Fix ifconfig parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ The following features are planned:
  
 3. On your server, copy the systemd service file `aliaser.service` to `/etc/systemd/system/aliaser.service`
 
-4. Copy the shell script `aliaser` to `/usr/bin/aliaser`
+4. Copy the shell script `aliaser` to `/usr/sbin/aliaser`
 
 5. Assign the script an executable bit to the shell script as follows:
 
-       `#chmod +x /usr/bin/aliaser`
+       `#chmod +x /usr/sbin/aliaser`
        
 6. `aliaser` will is now installed! Start the `aliaser` service:
 
@@ -79,6 +79,8 @@ The following features are planned:
 
 The output of `curl http://169.254.169.254/latest/meta-data/public-ipv4` has proven unpredictable. Unfortunately the Primary Public IP filed for
 `./aliaser print` initially relied on this EC2 API call. I am working on formatting another option that will produce stable output. This does not impact the actual functionality of the IP address allocation.
+
+Please be sure to install `curl` (through your package management tool) before installing aliaser
 
 ### Licensing and Copyright
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ PGP Key 0x30D2ABDB2DF72435
 
 A service written in bash to resolve ongoing issues with IP aliasing when using Amazon EC2 virtual machines without the benefit of ec2-net-utils.
 
-###Features
+### Features
 
 - Adds and removes routing table entries on RHEL Amazon EC2 virtual machines to support the mapping of multiple public IP addresses to the same EC2 instance.
 
@@ -22,7 +22,7 @@ A service written in bash to resolve ongoing issues with IP aliasing when using 
 
 - Multiple IP mappings are supported
 
-###To Do
+### To Do
 
 The following features are planned:
 

--- a/aliaser
+++ b/aliaser
@@ -19,10 +19,18 @@ fi
 #printf "\n"
 #declare -a ETHINT=($interface)
 
-#case $ETHINT in 
+ETHINT=${ETHINT:-eth0}
 
 function mac-grab {
-	MAC_ADDR=$(ifconfig eth0 | sed -n 's/.*ether \([a-f0-9:]*\).*/\1/p')
+	MAC_ADDR=$(ip addr list $ETHINT | sed -n 's/.*link\/ether \([a-f0-9:]*\).*/\1/p')
+	if test -z "$MAC_ADDR" ; then
+	    MAC_ADDR=$(ifconfig $ETHINT | sed -n 's/.*ether \([a-f0-9:]*\).*/\1/p')
+	fi
+	if test -z "$MAC_ADDR" ; then
+	    echo "Can't determine mac address, giving up"
+	    exit 1
+	fi
+	MAC_ADDR=$(echo "$MAC_ADDR" | tr 'A-F' 'a-f')
 }
 
 function public-grab {
@@ -38,10 +46,11 @@ function primary-private-grab {
 }
 
 function private-loop {
+        local priv
 	for priv in ${PRIVATE[@]:1};
         do
                 echo "Adding IP: $priv"
-                ip addr add dev eth0 $priv/$SUBNET_CIDR_BLOCK
+                ip addr add dev $ETHINT $priv/$SUBNET_CIDR_BLOCK
         done
 }
 

--- a/aliaser.service
+++ b/aliaser.service
@@ -10,9 +10,9 @@ Type=oneshot
 User=root
 RemainAfterExit=yes
 
-ExecStart=/usr/bin/aliaser start
-ExecReload=/usr/bin/aliaser reload
-ExecStop=/usr/bin/aliaser stop
+ExecStart=/usr/sbin/aliaser start
+ExecReload=/usr/sbin/aliaser reload
+ExecStop=/usr/sbin/aliaser stop
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Fixed some small issues...
BTW: Thank you for the script and the necessary information! :-)

Things done
* Minor markdown fix
* Made MAC detection more robust. `ifconfig` is only used as fallback, since most of the time we use `ip` in this script anyway...
* Changed installation folder from /usr/bin/ to /usr/sbin since this script may only be run by root as it does change IP addresses. Linux FHS says to install such scripts in a "root only" folder